### PR TITLE
Fix handling of scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ You may extend the default scopes (`openid email profile`) by adding a `scopes` 
     'client_secret' => env('OIDC_CLIENT_SECRET'),
     'redirect' => env('OIDC_REDIRECT_URI'),
     
-    'scopes' => 'groups roles',
+    'scopes' => ['groups', 'roles'],
     // or
-    'scopes' => env('OIDC_SCOPES'),
+    'scopes' => explode(' ', env('OIDC_SCOPES')),
 ],
 ```
 

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -105,18 +105,6 @@ class Provider extends AbstractProvider
     /**
      * {@inheritdoc}
      */
-    public function getScopes(): array
-    {
-        if ($this->getConfig('scopes')) {
-            return array_merge($this->scopes, explode(' ', $this->getConfig('scopes')));
-        }
-
-        return $this->scopes;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function getTokenUrl()
     {
         return $this->getOpenIdConfig()['token_endpoint'];


### PR DESCRIPTION
This fixes the duplicate scopes added by this package, from my testing both old configs and new configs will continue to work as expected although everyone should probably alter their config to use a list of strings for scopes rather than a space delimited string. See "testing"

What this does:
This package relies on `socialiteproviders/manager` which already handles configuring scopes for us, this package has its own scope logic which causes scopes to be added twice, this PR fixes this.

Testing
I've tested this change both with `'scopes' => 'test1 test2'` as well as `'scopes' => ['test1', 'test2']` and both still work; the authorization URL formats the scopes correctly and the default scopes set by this package are still added. One small detail is that the scopes property will contain the value `test1 test2'` rather than the values `'test1'` and `'test2'` when all scopes are passed as a singlular string, this isn't new and was the cause for https://github.com/Kovah/laravel-socialite-oidc/issues/14 

Fixes https://github.com/Kovah/laravel-socialite-oidc/issues/14