### PR TITLE
Improve compatability with OIDC spec

### DIFF
--- a/src/EmptyEmailException.php
+++ b/src/EmptyEmailException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace SocialiteProviders\OIDC;
-
-use InvalidArgumentException;
-
-class EmptyEmailException extends InvalidArgumentException
-{
-}

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -390,8 +390,8 @@ class Provider extends AbstractProvider
         return (new User())->setRaw($user)->map(
             [
                 ...$user,
-                'id' => Arr::get($user, 'sub'),
-                'avatar' => Arr::get($user, 'picture'),
+                'id' => $user['sub'],
+                'avatar' => $user['picture'] ?? null,
             ]
         );
     }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Cache;
 use JsonException;
 use SocialiteProviders\Manager\OAuth2\AbstractProvider;
 use SocialiteProviders\Manager\OAuth2\User;
+use Illuminate\Support\Arr;
 
 /**
  * Generic OpenID Connect provider for Laravel Socialite
@@ -388,17 +389,9 @@ class Provider extends AbstractProvider
     {
         return (new User())->setRaw($user)->map(
             [
-                'id' => $user['sub'],
-
-                'email' => $user['email'] ?? null,
-                'name' => $user['name'] ?? null,
-                'nickname' => $user['nickname'] ?? null,
-                'given_name' => $user['given_name'] ?? null,
-                'family_name' => $user['family_name'] ?? null,
-
-                'idp' => $user['idp'] ?? null,
-                'role' => $user['role'] ?? null,
-                'groups' => $user['groups'] ?? null,
+                ...$user,
+                'id' => Arr::get($user, 'sub'),
+                'avatar' => Arr::get($user, 'picture'),
             ]
         );
     }

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -285,14 +285,6 @@ class Provider extends AbstractProvider
             $this->request->input('code')
         );
 
-        if ($this->hasEmptyEmail($payload)) {
-            $payload = $this->getUserByToken($tokenResponse['access_token']);
-            $email = $payload['email'] ?? null;
-            if (! $email) {
-                throw new EmptyEmailException('JWT: User has no email.', 401);
-            }
-        }
-
         $this->user = $this->mapUserToObject((array)$payload);
 
         return $this->user->setToken($tokenResponse['access_token'])
@@ -387,11 +379,6 @@ class Provider extends AbstractProvider
         }
 
         return !(strlen($nonce) > 0 && $nonce === $this->getCurrentNonce());
-    }
-
-    protected function hasEmptyEmail($payload)
-    {
-        return !isset($payload->email) || strlen($payload->email) == 0;
     }
 
     /**

--- a/src/Provider.php
+++ b/src/Provider.php
@@ -422,12 +422,11 @@ class Provider extends AbstractProvider
     protected function getUserByToken($token)
     {
         $response = $this->getHttpClient()->get(
-            $this->getUserInfoUrl() . '?' . http_build_query([
-                'access_token' => $token,
-            ]),
+            $this->getUserInfoUrl(),
             [
                 RequestOptions::HEADERS => [
                     'Accept' => 'application/json',
+                    'Authorization' => 'Bearer ' . $token,
                 ],
             ]
         );


### PR DESCRIPTION
Hi @Kovah, thanks for maintaining this package!

With a general view to improving compatibly with the OIDC specification, this PR does three things:
- Removes the exception thrown if a JWT doesn't include an email claim. An email claim isn't required by the OIDC specification and there are genuine reasons why it might not be included (missing necessary scopes, privacy, etc). If an application expects the email claim to be filled, that logic should move into the application codebase itself.
- Swaps the `getUserByToken($token)` method to use the Authorization header for transmitting the bearer token, instead of the URI query parameter approach. The Authorization header is the default strategy [recommended by OAuth/OIDC](https://datatracker.ietf.org/doc/html/rfc6750#section-1.2:~:text=Clients%20SHOULD%20make%20authenticated%20requests%20with%20a%20bearer%20token%20using%0A%20%20%20the%20%22Authorization%22%20request%20header%20field%20with%20the%20%22Bearer%22%20HTTP%0A%20%20%20authorization%20scheme.%20%20Resource%20servers%20MUST%20support%20this%20method.).
- Simplifies the mapping of JWT claims to the abstract user class, allowing for any custom claims that might be included on the JWT.

This does introduce some breaking changes:
- As noted above, anyone relying on the email claim being present would need to implement logic to handle that themselves within their own applications.
- Some OIDC servers may not support sending the bearer token via Authorization header, however this seems highly unlikely given that it's required by the specification. 